### PR TITLE
implements "xit" and "it SPECIFICATION" only pattern

### DIFF
--- a/lib/Test/Ika.pm
+++ b/lib/Test/Ika.pm
@@ -219,6 +219,10 @@ It's alias of 'describe' function.
 
 Create new L<Test::Ika::Example>.
 
+=item xit($name, $code)
+
+Create new L<Test::Ika::Example> which marked "disabled".
+
 =item before_suite(\&code)
 
 Register hook.

--- a/lib/Test/Ika.pm
+++ b/lib/Test/Ika.pm
@@ -14,6 +14,7 @@ use parent qw/Exporter/;
 
 our @EXPORT = (qw(
     describe it context
+    xit
     before_suite after_suite
     before_all after_all before_each after_each
     runtests
@@ -65,6 +66,12 @@ sub describe {
 sub it {
     my ($name, $code) = @_;
     my $it = Test::Ika::Example->new(name => $name, code => $code);
+    $CURRENT->add_example($it);
+}
+
+sub xit {
+    my ($name, $code) = @_;
+    my $it = Test::Ika::Example->new(name => $name, code => $code, skip => 1);
     $CURRENT->add_example($it);
 }
 

--- a/lib/Test/Ika/Example.pm
+++ b/lib/Test/Ika/Example.pm
@@ -10,11 +10,15 @@ use Test::Builder;
 sub new {
     my $class = shift;
     my %args = @_==1 ? %{$_[0]} : @_;
+
     my $name = delete $args{name} || Carp::croak "Missing name";
-    my $code = delete $args{code} || Carp::croak "Missing code";
+    my $code = delete $args{code}; # allow specification only
+    my $skip = exists $args{skip} ? delete $args{skip} : (!$code ? 1 : 0); # xit
+
     bless {
         name => $name,
         code => $code,
+        skip => $skip,
     }, $class;
 }
 
@@ -36,7 +40,12 @@ sub run {
             $builder->failure_output($fh);
             $builder->todo_output($fh);
 
+            if ($self->{skip}) {
+                $builder->skip;
+            }
+            else {
                 $self->{code}->();
+            }
 
             $builder->finalize();
             $builder->is_passing();
@@ -44,7 +53,11 @@ sub run {
     } catch {
         $error = "$_";
     } finally {
-        $Test::Ika::REPORTER->it($self->{name}, !!$ok, $output, $error);
+        my $name = $self->{name};
+        if ($self->{skip}) {
+            $name .= $self->{code} ? ' [DISABLED]' : ' [NOT IMPLEMENTED]';
+        }
+        $Test::Ika::REPORTER->it($name, !!$ok, $output, $error);
     };
 }
 

--- a/lib/Test/Ika/Example.pm
+++ b/lib/Test/Ika/Example.pm
@@ -57,7 +57,10 @@ sub run {
         if ($self->{skip}) {
             $name .= $self->{code} ? ' [DISABLED]' : ' [NOT IMPLEMENTED]';
         }
-        $Test::Ika::REPORTER->it($name, !!$ok, $output, $error);
+
+        my $test = $self->{skip} ? -1 : !!$ok;
+
+        $Test::Ika::REPORTER->it($name, $test, $output, $error);
     };
 }
 

--- a/lib/Test/Ika/Reporter/Spec.pm
+++ b/lib/Test/Ika/Reporter/Spec.pm
@@ -36,8 +36,11 @@ sub it {
     my ($self, $name, $test, $results, $exception) = @_;
 
     print ('  ' x (@{$self->{describe}}+1));
-    if ($test) {
+    if ($test > 0) {
         print( colored( ['green'], "\x{2713} " ) );
+    }
+    elsif ($test < 0) {
+        print( colored( ['yellow'], "\x{2713} " ) );
     }
     else {
         # not ok

--- a/t/08_xit.t
+++ b/t/08_xit.t
@@ -1,0 +1,62 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use Test::Ika;
+use Test::Ika::Reporter::Test;
+
+my $reporter = Test::Ika::Reporter::Test->new();
+local $Test::Ika::REPORTER = $reporter;
+my @RESULT;
+{
+    package sandbox;
+    use Test::Ika;
+    use Test::More;
+
+    describe 'foo' => sub {
+        before_all {
+            push @RESULT, 'BEFORE ALL foo';
+        };
+        after_all {
+            push @RESULT, 'AFTER ALL foo';
+        };
+        before_each {
+            push @RESULT, 'BEFORE EACH foo';
+        };
+        after_each {
+            push @RESULT, 'AFTER EACH foo';
+        };
+
+        it 'bar' => sub {
+            push @RESULT, 'test bar';
+        };
+
+        it 'baz';
+
+        xit 'quux' => sub {
+            push @RESULT, 'test quux';
+        };
+    };
+
+    runtests;
+}
+is(join("\n", @RESULT), join("\n", (
+    'BEFORE ALL foo',
+        'BEFORE EACH foo',
+            'test bar',
+        'AFTER EACH foo',
+        'BEFORE EACH foo',
+            # spec 'baz' only
+        'AFTER EACH foo',
+        'BEFORE EACH foo',
+            # skip xit spec 'quux'
+        'AFTER EACH foo',
+    'AFTER ALL foo',
+)));
+
+is scalar @{$reporter->report} => 3;
+like $reporter->report->[1]->[1] => qr/NOT IMPLEMENTED/;
+like $reporter->report->[2]->[1] => qr/DISABLED/;
+
+done_testing;
+


### PR DESCRIPTION
there are ok.

```
describe 'foo' => sub {
    it 'bar' => sub { ... };
    it 'baz'; # marked as 'NOT IMPLEMENTED'
    xit 'quux' => sub { ... }; # marked as 'DISABLED'
};
```
