### PR TITLE
Tagged example

### DIFF
--- a/lib/Test/Ika.pm
+++ b/lib/Test/Ika.pm
@@ -64,14 +64,16 @@ sub describe {
 *context = *describe;
 
 sub it {
-    my ($name, $code) = @_;
-    my $it = Test::Ika::Example->new(name => $name, code => $code);
+    my $code = ref $_[-1] eq 'CODE' ? pop : undef;
+    my ($name, $tags) = @_;
+    my $it = Test::Ika::Example->new(name => $name, code => $code, tags => $tags);
     $CURRENT->add_example($it);
 }
 
 sub xit {
-    my ($name, $code) = @_;
-    my $it = Test::Ika::Example->new(name => $name, code => $code, skip => 1);
+    my $code = ref $_[-1] eq 'CODE' ? pop : undef;
+    my ($name, $tags) = @_;
+    my $it = Test::Ika::Example->new(name => $name, code => $code, tags => $tags, skip => 1);
     $CURRENT->add_example($it);
 }
 

--- a/lib/Test/Ika.pm
+++ b/lib/Test/Ika.pm
@@ -221,6 +221,13 @@ It's alias of 'describe' function.
 
 Create new L<Test::Ika::Example>.
 
+=item it($name, \%tags, $code)
+
+Create new L<Test::Ika::Example> with tags.
+
+Tags is a HASH reference.
+It's compared to C<%ENV> at runtime, and run example if they match.
+
 =item xit($name, $code)
 
 Create new L<Test::Ika::Example> which marked "disabled".

--- a/lib/Test/Ika/Example.pm
+++ b/lib/Test/Ika/Example.pm
@@ -33,8 +33,16 @@ sub run {
 
     if (defined $self->{tags} && defined $self->{code}) {
         my @keys = keys %{$self->{tags}};
-        my $match = scalar(grep { exists $ENV{$_} && $ENV{$_} eq $self->{tags}->{$_} } @keys) || 0;
-        $self->{skip}++ if @keys > 0 && $match != @keys;
+
+        my $match = 0;
+        for my $key (@keys) {
+            next unless exists $ENV{$key};
+
+            my $value = $self->{tags}->{$key};
+            $match++ if (ref $value eq 'Regexp' ? ($ENV{$key} =~ $value) : ($ENV{$key} eq $value));
+        }
+
+        $self->{skip}++ if $match != @keys;
     };
 
     try {

--- a/lib/Test/Ika/Example.pm
+++ b/lib/Test/Ika/Example.pm
@@ -14,11 +14,13 @@ sub new {
     my $name = delete $args{name} || Carp::croak "Missing name";
     my $code = delete $args{code}; # allow specification only
     my $skip = exists $args{skip} ? delete $args{skip} : (!$code ? 1 : 0); # xit
+    my $tags = delete $args{tags};
 
     bless {
         name => $name,
         code => $code,
         skip => $skip,
+        tags => $tags,
     }, $class;
 }
 
@@ -28,6 +30,13 @@ sub run {
     my $error;
     my $ok;
     my $output = "";
+
+    if (defined $self->{tags} && defined $self->{code}) {
+        my @keys = keys %{$self->{tags}};
+        my $match = scalar(grep { exists $ENV{$_} && $ENV{$_} eq $self->{tags}->{$_} } @keys) || 0;
+        $self->{skip}++ if @keys > 0 && $match != @keys;
+    };
+
     try {
         open my $fh, '>', \$output;
         $ok = do {

--- a/t/09_tags.t
+++ b/t/09_tags.t
@@ -1,0 +1,46 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use Test::Ika;
+use Test::Ika::Reporter::Test;
+
+my $reporter = Test::Ika::Reporter::Test->new();
+local $Test::Ika::REPORTER = $reporter;
+my @RESULT;
+{
+    package sandbox;
+    use Test::Ika;
+    use Test::More;
+
+    $ENV{"TEST_IKA_TAG${_}"} = 1 for 1..6;
+
+    describe 'foo' => sub {
+        it 'foo' => { TEST_IKA_TAG1 => 1 } => sub {
+            push @RESULT, 'test foo';
+        };
+
+        it 'bar' => { TEST_IKA_TAG2 => 'bar' } => sub {
+            push @RESULT, 'test bar';
+        };
+
+        it 'baz' => { TEST_IKA_TAG3 => 1, TEST_IKA_TAG4 => 1 } => sub {
+            push @RESULT, 'test baz';
+        };
+
+        it 'quux' => { TEST_IKA_TAG5 => 1, TEST_IKA_TAG6 => 'quux' } => sub {
+            push @RESULT, 'test quux';
+        };
+    };
+
+    runtests;
+}
+is(join("\n", @RESULT), join("\n", (
+    'test foo',
+    # skip test bar
+    'test baz',
+    # skip test quux
+)));
+
+done_testing;
+


### PR DESCRIPTION
https://www.relishapp.com/rspec/rspec-core/v/2-4/docs/command-line/tag-option を何とか移植してみた結果、こんな書き方ができるようになって、%ENV と比較してマッチする example だけ実行するんだけど、正直微妙な感もある。。。

```
it 'SPEC' => { ENV_FOO => 1, ... } => sub { ... };
```
