### PR TITLE
Conditional example

### DIFF
--- a/lib/Test/Ika.pm
+++ b/lib/Test/Ika.pm
@@ -15,6 +15,7 @@ use parent qw/Exporter/;
 our @EXPORT = (qw(
     describe it context
     xit
+    when
     before_suite after_suite
     before_all after_all before_each after_each
     runtests
@@ -63,15 +64,21 @@ sub describe {
 }
 *context = *describe;
 
+sub when (&) {
+    return $_[0];
+}
+
 sub it {
-    my ($name, $code) = @_;
-    my $it = Test::Ika::Example->new(name => $name, code => $code);
+    my $code = ref $_[-1] eq 'CODE' ? pop : undef;
+    my ($name, $cond) = @_;
+    my $it = Test::Ika::Example->new(name => $name, code => $code, cond => $cond);
     $CURRENT->add_example($it);
 }
 
 sub xit {
-    my ($name, $code) = @_;
-    my $it = Test::Ika::Example->new(name => $name, code => $code, skip => 1);
+    my $code = ref $_[-1] eq 'CODE' ? pop : undef;
+    my ($name, $cond) = @_;
+    my $it = Test::Ika::Example->new(name => $name, code => $code, cond => $cond, skip => 1);
     $CURRENT->add_example($it);
 }
 
@@ -215,11 +222,30 @@ Create new L<Test::Ika::ExampleGroup>.
 
 It's alias of 'describe' function.
 
-=item it($name, $code)
+=item it($name, \&code)
 
 Create new L<Test::Ika::Example>.
 
-=item xit($name, $code)
+=item it($name, $cond, \&code)
+
+Create new conditional L<Test::Ika::Example>.
+
+C<$cond> is usually a sub-routine reference.
+You can set it with C<when> statement.
+
+  # run this example, when "sub { $ENV{TEST_MESSAGE} }" returns true
+  it 'should detect message', when { $ENV{TEST_MESSAGE} } => sub {
+      my $filter = MessageFilter->new('foo');
+      expect($filter->detect('hello foo'))->ok;
+  };
+
+=item when(\&code)
+
+Set conditional sub-routine for it/xit.
+
+=item xit($name, \&code)
+
+=item xit($name, $cond, \&code)
 
 Create new L<Test::Ika::Example> which marked "disabled".
 

--- a/lib/Test/Ika.pm
+++ b/lib/Test/Ika.pm
@@ -231,17 +231,27 @@ Create new L<Test::Ika::Example>.
 Create new conditional L<Test::Ika::Example>.
 
 C<$cond> is usually a sub-routine reference.
-You can set it with C<when> statement.
+You can set it with "when" statement.
 
-  # run this example, when "sub { $ENV{TEST_MESSAGE} }" returns true
-  it 'should detect message', when { $ENV{TEST_MESSAGE} } => sub {
+  # run this example, if C<$ENV{TEST_MESSAGE}> returns true
+
+  my $cond = sub { $ENV{TEST_MESSAGE} };
+
+  it 'should detect message', $cond => sub {
       my $filter = MessageFilter->new('foo');
       expect($filter->detect('hello foo'))->ok;
   };
 
 =item when(\&code)
 
-Set conditional sub-routine for it/xit.
+Specify conditional sub-routine.
+
+You can write conditional example as shown below:
+
+  it 'should detect message', when { $ENV{TEST_MESSAGE} } => sub {
+      my $filter = MessageFilter->new('foo');
+      expect($filter->detect('hello foo'))->ok;
+  };
 
 =item xit($name, \&code)
 

--- a/t/09_conditional.t
+++ b/t/09_conditional.t
@@ -1,0 +1,51 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use Test::Ika;
+use Test::Ika::Reporter::Test;
+
+my $reporter = Test::Ika::Reporter::Test->new();
+local $Test::Ika::REPORTER = $reporter;
+my @RESULT;
+{
+    package sandbox;
+    use Test::Ika;
+    use Test::More;
+
+    $ENV{TEST_IKA_COND1} = 1;
+    undef $ENV{TEST_IKA_COND2};
+
+    describe 'foo' => sub {
+        it 'uncondition' => sub {
+            push @RESULT, 'test uncondition';
+        };
+
+        it 'foo', when { $ENV{TEST_IKA_COND1} } => sub {
+            push @RESULT, 'test foo';
+        };
+
+        it 'bar', when { $ENV{TEST_IKA_COND2} } => sub {
+            push @RESULT, 'test bar';
+        };
+
+        it 'baz', 1 => sub {
+            push @RESULT, 'test baz';
+        };
+
+        it 'quux', 0 => sub {
+            push @RESULT, 'test quux';
+        };
+    };
+
+    runtests;
+}
+is(join("\n", @RESULT), join("\n", (
+    'test uncondition',
+    'test foo',
+    # skip test bar
+    'test baz',
+    # skip test quux
+)));
+
+done_testing;


### PR DESCRIPTION
rewrite tagged example.

run this example if $condition returns true.

``` perl
it '...', when { $condition } => sub {
    ok(1);
};
```
