### PR TITLE
enable "xdescribe" and "xcontext"

### DIFF
--- a/lib/Test/Ika.pm
+++ b/lib/Test/Ika.pm
@@ -13,8 +13,8 @@ use Test::Ika::Example;
 use parent qw/Exporter/;
 
 our @EXPORT = (qw(
-    describe it context
-    xit
+    describe context it
+    xdescribe xcontext xit
     when
     before_suite after_suite
     before_all after_all before_each after_each
@@ -81,6 +81,24 @@ sub xit {
     my $it = Test::Ika::Example->new(name => $name, code => $code, cond => $cond, skip => 1);
     $CURRENT->add_example($it);
 }
+
+sub xdescribe {
+    my $caller = caller(0);
+
+    no strict 'refs';
+    no warnings 'redefine';
+
+    local *{"${caller}::it"} = \&xit;
+
+    my $noop = sub {};
+    local *{"${caller}::before_all"}  = $noop;
+    local *{"${caller}::after_all"}   = $noop;
+    local *{"${caller}::before_each"} = $noop;
+    local *{"${caller}::after_each"}  = $noop;
+
+    describe(@_);
+}
+*xcontext = \&xdescribe;
 
 sub before_suite(&) {
     my $code = shift;

--- a/t/10_xdescribe.t
+++ b/t/10_xdescribe.t
@@ -1,0 +1,52 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use Test::Ika;
+use Test::Ika::Reporter::Test;
+
+my $reporter = Test::Ika::Reporter::Test->new();
+local $Test::Ika::REPORTER = $reporter;
+my @RESULT;
+{
+    package sandbox;
+    use Test::Ika;
+    use Test::More;
+
+    xdescribe 'foo' => sub {
+        before_all {
+            push @RESULT, 'BEFORE ALL foo';
+        };
+        after_all {
+            push @RESULT, 'AFTER ALL foo';
+        };
+        before_each {
+            push @RESULT, 'BEFORE EACH foo';
+        };
+        after_each {
+            push @RESULT, 'AFTER EACH foo';
+        };
+
+        it 'bar' => sub {
+            push @RESULT, 'test bar';
+        };
+
+        it 'baz';
+
+        xit 'quux' => sub {
+            push @RESULT, 'test quux';
+        };
+    };
+
+    runtests;
+}
+
+is(join("\n", @RESULT), '');
+
+is scalar @{$reporter->report} => 3;
+like $reporter->report->[0]->[1] => qr/DISABLED/; # normal case is disabled
+like $reporter->report->[1]->[1] => qr/NOT IMPLEMENTED/;
+like $reporter->report->[2]->[1] => qr/DISABLED/;
+
+done_testing;
+

--- a/t/11_xcontext.t
+++ b/t/11_xcontext.t
@@ -1,0 +1,94 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use Test::Ika;
+use Test::Ika::Reporter::Test;
+
+my $reporter = Test::Ika::Reporter::Test->new();
+local $Test::Ika::REPORTER = $reporter;
+my @RESULT;
+{
+    package sandbox;
+    use Test::Ika;
+    use Test::More;
+
+    describe 'foo' => sub {
+        xcontext 'xcontext' => sub {
+            before_all {
+                push @RESULT, 'BEFORE ALL foo xcontext';
+            };
+            after_all {
+                push @RESULT, 'AFTER ALL foo xcontext';
+            };
+            before_each {
+                push @RESULT, 'BEFORE EACH foo xcontext';
+            };
+            after_each {
+                push @RESULT, 'AFTER EACH foo xcontext';
+            };
+
+            it 'bar' => sub {
+                push @RESULT, 'foo xcontext bar';
+            };
+
+            it 'baz';
+
+            xit 'quux' => sub {
+                push @RESULT, 'foo xcontext quux';
+            };
+        };
+
+        context 'normal' => sub {
+            before_all {
+                push @RESULT, 'BEFORE ALL foo normal';
+            };
+            after_all {
+                push @RESULT, 'AFTER ALL foo normal';
+            };
+            before_each {
+                push @RESULT, 'BEFORE EACH foo normal';
+            };
+            after_each {
+                push @RESULT, 'AFTER EACH foo normal';
+            };
+
+            it 'bar' => sub {
+                push @RESULT, 'foo normal bar';
+            };
+
+            it 'baz';
+
+            xit 'quux' => sub {
+                push @RESULT, 'foo normal quux';
+            };
+        };
+    };
+
+    runtests;
+}
+
+is(join("\n", @RESULT), join("\n", (
+    'BEFORE ALL foo normal',
+        'BEFORE EACH foo normal',
+            'foo normal bar',
+        'AFTER EACH foo normal',
+        'BEFORE EACH foo normal',
+            # spec 'baz' only
+        'AFTER EACH foo normal',
+        'BEFORE EACH foo normal',
+            # skip xit spec 'quux'
+        'AFTER EACH foo normal',
+    'AFTER ALL foo normal',
+)));
+
+is scalar @{$reporter->report} => 6;
+like $reporter->report->[0]->[1] => qr/DISABLED/; # normal case is disabled
+like $reporter->report->[1]->[1] => qr/NOT IMPLEMENTED/;
+like $reporter->report->[2]->[1] => qr/DISABLED/;
+unlike $reporter->report->[3]->[1] => qr/DISABLED/; # it is under context
+like $reporter->report->[4]->[1] => qr/NOT IMPLEMENTED/;
+like $reporter->report->[5]->[1] => qr/DISABLED/;
+
+done_testing;
+


### PR DESCRIPTION
use these instead of "describe" and "context", skip all cases under there.
- replace "it" to "xit" locally
- ignore "before_all", "after_all", "before_each", and "after_each" locally
