### PR TITLE
Output without color for spec format

### DIFF
--- a/lib/Test/Ika.pm
+++ b/lib/Test/Ika.pm
@@ -36,6 +36,13 @@ our $REPORTER;
 
 sub reporter { $REPORTER }
 
+sub build_reporter_option {
+    my $class = shift;
+    return +{
+        color => ! $ENV{TEST_IKA_NOCOLOR},
+    };
+}
+
 sub set_reporter {
     my ($class, $module) = @_;
     $REPORTER = $class->load_reporter($module);
@@ -46,12 +53,7 @@ sub load_reporter {
     $module = ($module =~ s/^\+// ? $module : "Test::Ika::Reporter::$module");
     Module::Load::load($module);
 
-    my $args = +{};
-    if ($module eq 'Test::Ika::Reporter::Spec' && $ENV{NOCOLOR}) {
-        $args->{color} = 0;
-    }
-
-    return $module->new($args);
+    return $module->new(__PACKAGE__->build_reporter_option);
 }
 
 sub describe {

--- a/lib/Test/Ika.pm
+++ b/lib/Test/Ika.pm
@@ -45,7 +45,13 @@ sub load_reporter {
     my ($class, $module) = @_;
     $module = ($module =~ s/^\+// ? $module : "Test::Ika::Reporter::$module");
     Module::Load::load($module);
-    return $module->new();
+
+    my $args = +{};
+    if ($module eq 'Test::Ika::Reporter::Spec' && $ENV{NOCOLOR}) {
+        $args->{color} = 0;
+    }
+
+    return $module->new($args);
 }
 
 sub describe {

--- a/lib/Test/Ika/Reporter/Spec.pm
+++ b/lib/Test/Ika/Reporter/Spec.pm
@@ -25,7 +25,7 @@ sub new {
     }, $class;
 }
 
-sub to_output {
+sub color {
     my ($self, $color, @args) = @_;
 
     return @args unless $self->{color};
@@ -46,16 +46,16 @@ sub it {
 
     print ('  ' x (@{$self->{describe}}+1));
     if ($test > 0) {
-        print( $self->to_output( ['green'], "\x{2713} " ) );
+        print( $self->color( ['green'], "\x{2713} " ) );
     }
     elsif ($test < 0) {
-        print( $self->to_output( ['yellow'], "\x{2713} " ) );
+        print( $self->color( ['yellow'], "\x{2713} " ) );
     }
     else {
         # not ok
-        print( $self->to_output( ['red'], "\x{2716} " ) );
+        print( $self->color( ['red'], "\x{2716} " ) );
     }
-    print( $self->to_output( ["BRIGHT_BLACK"], $name ) );
+    print( $self->color( ["BRIGHT_BLACK"], $name ) );
     if (!$test) {
         my $failed = ++$self->{failed};
         printf(" (FAILED - %d)", $failed);
@@ -80,7 +80,7 @@ sub finalize {
             }
             if (defined(my $err = $self->{results}->[$i]->[1])) {
                 $err =~ s{\n(?!\z)}{\n$indent}sg;
-                print $indent . $self->to_output(['red', 'bold'], 'Exception: ') . $self->to_output(['red'], $err);
+                print $indent . $self->color(['red', 'bold'], 'Exception: ') . $self->color(['red'], $err);
             }
         }
         print "\n";

--- a/lib/Test/Ika/Reporter/Spec.pm
+++ b/lib/Test/Ika/Reporter/Spec.pm
@@ -26,10 +26,10 @@ sub new {
 }
 
 sub to_output {
-    my ($self, @args) = @_;
+    my ($self, $color, @args) = @_;
 
-    return $args[1] unless $self->{color};
-    return Term::ANSIColor::colored(@args);
+    return @args unless $self->{color};
+    return Term::ANSIColor::colored($color, @args);
 }
 
 sub describe {

--- a/lib/Test/Ika/Reporter/Spec.pm
+++ b/lib/Test/Ika/Reporter/Spec.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use utf8;
 use Scope::Guard ();
-use Term::ANSIColor;
+use Term::ANSIColor qw/colored/;
 use Term::Encoding ();
 
 sub new {

--- a/t/01_reporters.t
+++ b/t/01_reporters.t
@@ -21,5 +21,5 @@ sub check {
 sub functions {
     my $klass = shift;
     no strict 'refs';
-    sort grep { $_ ne 'colored' && $_ ne 'to_output' } grep { defined &{"${klass}::$_"} } keys %{"${klass}::"};
+    sort grep { $_ ne 'colored' && $_ ne 'color' } grep { defined &{"${klass}::$_"} } keys %{"${klass}::"};
 }

--- a/t/01_reporters.t
+++ b/t/01_reporters.t
@@ -21,5 +21,5 @@ sub check {
 sub functions {
     my $klass = shift;
     no strict 'refs';
-    sort grep { $_ ne 'colored' } grep { defined &{"${klass}::$_"} } keys %{"${klass}::"};
+    sort grep { $_ ne 'colored' && $_ ne 'to_output' && $_ ne 'color' } grep { defined &{"${klass}::$_"} } keys %{"${klass}::"};
 }

--- a/t/01_reporters.t
+++ b/t/01_reporters.t
@@ -21,5 +21,5 @@ sub check {
 sub functions {
     my $klass = shift;
     no strict 'refs';
-    sort grep { $_ ne 'colored' && $_ ne 'to_output' && $_ ne 'color' } grep { defined &{"${klass}::$_"} } keys %{"${klass}::"};
+    sort grep { $_ ne 'colored' && $_ ne 'to_output' } grep { defined &{"${klass}::$_"} } keys %{"${klass}::"};
 }


### PR DESCRIPTION
`Test::Ika::Reporter::Spec` を利用している時に、カラー用のスケープシーケンスを付与しないモードを追加しました。
ENVにNOCOLOR=1と指定すると`Term::ANSIColor::colored` を回避して出力します。
本来であれば `Test::Ika::Reporter::Spec` をnewするときに引数で指定できればいいのですが、 Reporterを必要とする`Test::Ika` はインスタンス化されずに利用され、かつReporterは動的にロードされるのでこの方法がベターだと思いました。
( `HARNESS_ACTIVE` などもENVを利用しているので踏襲したという理由もあります。)
