### PR TITLE
Add JUnit reporter which logs in pretty format and spits out XML with metadata

### DIFF
--- a/META.json
+++ b/META.json
@@ -53,6 +53,9 @@
             "Test::More" : "0.98",
             "Test::Name::FromLine" : "0.06",
             "Try::Tiny" : "0",
+            "IO::Scalar" : "0",
+            "Time::HiRes" : "0",
+            "XML::Simple" : "0",
             "parent" : "0",
             "perl" : "5.010001"
          }
@@ -76,8 +79,9 @@
          "web" : "https://github.com/tokuhirom/Test-Ika"
       }
    },
-   "version" : "0.08",
+   "version" : "0.09",
    "x_contributors" : [
+      "Sahil Singla<er.singlasahil@gmail.com>",
       "Ryoichi SEKIGUCHI <ryopeko+free@gmail.com>",
       "Tokuhiro Matsuno <tokuhirom@gmail.com>",
       "Masaki Nakagawa <masaki.nakagawa@gmail.com>"

--- a/META.json
+++ b/META.json
@@ -53,9 +53,6 @@
             "Test::More" : "0.98",
             "Test::Name::FromLine" : "0.06",
             "Try::Tiny" : "0",
-            "IO::Scalar" : "0",
-            "Time::HiRes" : "0",
-            "XML::Simple" : "0",
             "parent" : "0",
             "perl" : "5.010001"
          }
@@ -79,9 +76,9 @@
          "web" : "https://github.com/tokuhirom/Test-Ika"
       }
    },
-   "version" : "0.09",
+   "version" : "0.08",
    "x_contributors" : [
-      "Sahil Singla<er.singlasahil@gmail.com>",
+      "Sahil Singla <er.singlasahil@gmail.com>",
       "Ryoichi SEKIGUCHI <ryopeko+free@gmail.com>",
       "Tokuhiro Matsuno <tokuhirom@gmail.com>",
       "Masaki Nakagawa <masaki.nakagawa@gmail.com>"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Test::Ika provides some reporters.
             <img src="https://raw.github.com/tokuhirom/Test-Ika/master/img/tap.png">
     </div>
 
+- The JUnit mode(same console output as that in spec mode, along with XML containing metadata logs for the tests run)
+
 # FUNCTIONS
 
 - `describe($name, $code)`

--- a/README.md
+++ b/README.md
@@ -66,6 +66,41 @@ Test::Ika provides some reporters.
 
 - The JUnit mode(same console output as that in spec mode, along with XML containing metadata logs for the tests run)
 
+    ```xml
+    <?xml version='1.0' encoding='utf-8'?>
+    <testsuites>
+        <testsuite name="Array" errors="2" failures="2" tests="3">
+            <testcase name="#push can push to array" time="0.003349">
+                <success></success>
+                <system-err></system-err>
+                <system-out>ok 1 - L31: is($a-&gt;size, 1);
+    </system-out>
+            </testcase>
+            <testcase name="#push put pushed element to tail" time="0.000649">
+                <failure></failure>
+                <system-err></system-err>
+                <system-out>not ok 1 - L37: is($a-&gt;at(0), 1);
+    #   Failed test 'L37: is($a-&gt;at(0), 1);'
+    #   at eg/oops.t line 37.
+    #          got: '2'
+    #     expected: '1'
+    </system-out>
+            </testcase>
+            <testcase name="#map can apply the function to array" time="0.000724">
+                <failure></failure>
+                <system-err></system-err>
+                <system-out>not ok 1 - L45: is_deeply([$a-&gt;map(sub { $_ * 2 })], [2,4]);
+    #   Failed test 'L45: is_deeply([$a-&gt;map(sub { $_ * 2 })], [2,4]);'
+    #   at eg/oops.t line 45.
+    #     Structures begin differing at:
+    #          $got-&gt;[0] = '4'
+    #     $expected-&gt;[0] = '2'
+    </system-out>
+            </testcase>
+        </testsuite>
+    </testsuites>
+    ```
+
 # FUNCTIONS
 
 - `describe($name, $code)`

--- a/cpanfile
+++ b/cpanfile
@@ -11,6 +11,9 @@ requires 'Test::Builder::Module';
 requires 'Test::More', '0.98';
 requires 'Test::Name::FromLine', '0.06';
 requires 'Try::Tiny';
+requires 'IO::Scalar';
+requires 'Time::HiRes';
+requires 'XML::Simple';
 
 on test => sub {
     requires 'Test::More', '0.98';

--- a/lib/Test/Ika/Reporter/JUnit.pm
+++ b/lib/Test/Ika/Reporter/JUnit.pm
@@ -1,0 +1,148 @@
+package Test::Ika::Reporter::JUnit;
+
+use strict;
+use warnings;
+use utf8;
+
+use Test::Ika::Reporter::Spec;
+
+use XML::Simple;
+use Time::HiRes qw(gettimeofday tv_interval);
+
+sub new {
+    my ($class, $args) = @_;
+
+    return bless {
+        tee        => Test::Ika::Reporter::Spec->new($args),
+        builder    => Test::Ika::Reporter::JUnit::IO->new,
+        time       => [ gettimeofday ],
+        test_suite => {},
+        describes  => [],
+    }, $class;
+}
+
+sub builder { shift->{builder} }
+
+sub describe {
+    my ($self, $name) = @_;
+
+    push @{$self->{describes}}, $name;
+    print(('  ' x @{$self->{describes}}) . "$name\n"); # as Test::Ika::Reporter::Spec;
+    return Scope::Guard->new(sub {
+        pop @{$self->{describes}};
+    });
+}
+
+sub it {
+    my ($self, $name, $test, $results, $exception) = @_;
+
+    print ('  ' x (@{$self->{describes}}+1)); # as Test::Ika::Reporeter::Spec;
+    $self->{tee}->it($name, $test, $results, $exception);
+
+    my $test_name = join " ", (@{$self->{describes}}[1..$#{$self->{describes}}], $name);
+
+    my $time   = tv_interval($self->{time});
+    $self->{time} = [ gettimeofday ];
+
+    my @result;
+    my $suite_name = @{$self->{describes}}[0];
+    $self->{test_suite}->{$suite_name}->{failed} //= 0;
+    if ($test > 0) {
+        $exception = $self->builder->fetch_output;
+        print $exception;
+        @result = (success => {});
+    } elsif ($test < 0) {
+        @result = (skipped => {});
+    } else {
+        # not ok
+        $self->{test_suite}->{$suite_name}->{failed} += 1;
+        $exception = $self->builder->fetch_output . ($exception || '');
+        print $exception;
+        @result = (failure => {});
+    }
+
+    push @{$self->{test_suite}->{$suite_name}->{cases}}, +{
+        name => $test_name,
+        time => $time,
+        'system-out' => { content => $results },
+        'system-err' => { content => $exception },
+        @result,
+    };
+}
+
+sub finalize {
+    my $self = shift;
+    $self->{tee}->finalize;
+
+    my %testsuites = ();
+    while (my ($suite_name, $hash) = each(%{$self->{test_suite}})) {
+        $testsuites{$suite_name} = {
+            tests    => scalar(@{$hash->{cases}}),
+            errors   => $hash->{failed},
+            failures => $hash->{failed},
+            testcase => $hash->{cases},
+        };
+    }
+    XMLout(
+        { testsuite => \%testsuites },
+        XMLDecl => "<?xml version='1.0' encoding='utf-8'?>",
+        RootName => 'testsuites',
+        OutputFile => $ENV{JUNIT_OUTPUT_FILE} // "junitoutput.xml",
+    );
+}
+
+1;
+
+package Test::Ika::Reporter::JUnit::IO;
+
+use IO::Scalar;
+use Term::ANSIColor;
+
+sub new {
+    my $class = shift;
+
+    return bless {
+        buffer => \my $buffer,
+    }, $class;
+}
+
+sub output {
+    return IO::Scalar->new(shift->{buffer});
+}
+
+sub failure_output {
+    return IO::Scalar->new(shift->{buffer});
+}
+
+sub fetch_output {
+    my $self = shift;
+
+    my $tmp = '';
+    if (defined $self->{buffer}) {
+        $tmp = ${$self->{buffer}} || '';
+        $tmp = Term::ANSIColor::colorstrip($tmp);
+
+        $self->{buffer} = \my $buffer;
+    }
+
+    return $tmp;
+}
+
+1;
+__END__
+
+=head1 NAME
+
+Test::Ika::Reporter::JUnit - Reporter like RSpec but also spits out XML
+
+=head1 SYNOPSIS
+
+    Test::Ika->set_reporter('JUnit');
+
+=head1 DESCRIPTION
+
+This module displays pretty output like RSpec, while also creating XML with necessary info for failures.
+
+=head1 SEE ALSO
+
+L<Test::Ika>

--- a/t/01_reporters.t
+++ b/t/01_reporters.t
@@ -8,6 +8,7 @@ use Test::Ika::Reporter::Test;
 
 check('Test::Ika::Reporter::TAP');
 check('Test::Ika::Reporter::Test');
+check('Test::Ika::Reporter::JUnit');
 
 done_testing;
 

--- a/t/01_reporters.t
+++ b/t/01_reporters.t
@@ -5,6 +5,7 @@ use Test::More;
 use Test::Ika::Reporter::Spec;
 use Test::Ika::Reporter::TAP;
 use Test::Ika::Reporter::Test;
+use Test::Ika::Reporter::JUnit;
 
 check('Test::Ika::Reporter::TAP');
 check('Test::Ika::Reporter::Test');


### PR DESCRIPTION
Added the JUnit reporter which logs out the test results in the same way as `Test::Ika::Formatter::Spec` but also spits out XML files containing metadata for the testruns (inclusive of the error logs if encountered any). 

@masaki : Please review
